### PR TITLE
Reading an src file

### DIFF
--- a/tasks/checkPages.js
+++ b/tasks/checkPages.js
@@ -201,7 +201,7 @@ module.exports = function(grunt) {
     var options = this.options();
 
     if (options.src) {
-      options.pageUrls = grunt.file.readJSON(src);
+      options.pageUrls = grunt.file.readJSON(options.src);
     }
 
     if (!options.pageUrls) {


### PR DESCRIPTION
so we can pass an array from a source file directly

options: {
src: 'blah.json'
}

or whatever where blah.json =
["http://google.com","http://yahoo.com"]

ect.

Let me know if this is feasible or you'd rather do it a different way. I just override pageUrls directly if src is defined.
